### PR TITLE
Make it build with dataformats instead of daq-rawdata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(daq-cmake REQUIRED)
 daq_setup_environment()
 
 find_package(appfwk REQUIRED)
-find_package(daq-rawdata REQUIRED)
+find_package(dataformats REQUIRED)
 find_package(udaq_readout_deps REQUIRED)
 find_package(folly REQUIRED)
 find_package(TBB REQUIRED)
@@ -14,7 +14,7 @@ find_package(TBB REQUIRED)
 ##############################################################################
 # Dependency sets
 set(FLXCARD_DEPENDENCIES udaq_readout_deps::FlxCard udaq_readout_deps::cmem_rcc)
-set(FLXUTIL_DEPENDENCIES daq-rawdata udaq_readout_deps::packetformat Folly::folly ${TBB} ${TBB_IMPORTED_TARGETS})
+set(FLXUTIL_DEPENDENCIES dataformats::dataformats udaq_readout_deps::packetformat Folly::folly ${TBB} ${TBB_IMPORTED_TARGETS})
 
 ##############################################################################
 # Main library

--- a/cmake/readoutConfig.cmake.in
+++ b/cmake/readoutConfig.cmake.in
@@ -4,7 +4,7 @@
 include(CMakeFindDependencyMacro)
 
 find_dependency(appfwk)
-find_dependency(daq-rawdata)
+find_dependency(dataformats)
 find_dependency(udaq_readout_deps)
 find_dependency(folly)
 find_dependency(TBB)

--- a/plugins/FakeCardReader.cpp
+++ b/plugins/FakeCardReader.cpp
@@ -12,7 +12,7 @@
 #include "ReadoutIssues.hpp"
 #include "ReadoutConstants.hpp"
 
-#include "daq-rawdata/wib/WIBFrame.hpp"
+#include "dataformats/wib/WIBFrame.hpp"
 #include "appfwk/cmd/Nljs.hpp"
 
 #include <fstream>
@@ -114,7 +114,7 @@ FakeCardReader::do_work(std::atomic<bool>& running_flag)
   // This should be changed in case of a generic Fake ELink reader (exercise with TPs dumps)
   unsigned num_elem = source_buffer_->num_elements();
   unsigned num_frames = num_elem * 12;
-  uint64_t ts_0 = reinterpret_cast<dunedaq::rawdata::WIBFrame*>(source.data())->wib_header()->timestamp();
+  uint64_t ts_0 = reinterpret_cast<dunedaq::dataformats::WIBFrame*>(source.data())->wib_header()->timestamp();
   ERS_INFO("First timestamp in the source file: " << ts_0);
   uint64_t ts_next = ts_0;
 
@@ -131,8 +131,8 @@ FakeCardReader::do_work(std::atomic<bool>& running_flag)
 
     // fake the timestamp
     for (unsigned int i=0; i<12; ++i) {
-      auto* wf = reinterpret_cast<dunedaq::rawdata::WIBFrame*>(((uint8_t*)payload_ptr.get())+i*464);
-      auto* wfh = const_cast<dunedaq::rawdata::WIBHeader*>(wf->wib_header()); 
+      auto* wf = reinterpret_cast<dunedaq::dataformats::WIBFrame*>(((uint8_t*)payload_ptr.get())+i*464);
+      auto* wfh = const_cast<dunedaq::dataformats::WIBHeader*>(wf->wib_header()); 
       wfh->set_timestamp(ts_next);
       ts_next += 25;
     }

--- a/src/WIBFrameGrapProcessor.hpp
+++ b/src/WIBFrameGrapProcessor.hpp
@@ -11,7 +11,7 @@
 
 #include "GraphRawProcessor.hpp"
 
-#include "daq-rawdata/wib/WIBFrame.hpp"
+#include "dataformats/wib/WIBFrame.hpp"
 
 #include <functional>
 #include <atomic>
@@ -25,7 +25,7 @@ class WIBFrameGraphProcessor : public GraphRawProcessor<types::WIB_SUPERCHUNK_ST
 
 public:
   using frameptr = types::WIB_SUPERCHUNK_STRUCT*;
-  using wibframeptr = dunedaq::rawdata::WIBFrame*;
+  using wibframeptr = dunedaq::dataformats::WIBFrame*;
   using funcnode_t = tbb::flow::function_node<frameptr, frameptr>;
 
   explicit WIBFrameGraphProcessor(const std::string& rawtype, std::function<void(frameptr)>& process_override)
@@ -51,7 +51,7 @@ public:
     uint64_t counter = 0;
     bool first = true;
     frameptr operator()(frameptr fp) {
-      auto* wfptr = reinterpret_cast<dunedaq::rawdata::WIBFrame*>(fp);
+      auto* wfptr = reinterpret_cast<dunedaq::dataformats::WIBFrame*>(fp);
       ts_next = wfptr->timestamp();
       //std::cout << " TS: " << wfptr->timestamp() << " stored: " << ts_next << '\n'; 
       if (ts_next - ts_prev != 300) {
@@ -72,7 +72,7 @@ public:
     uint8_t s1err = 0;
     uint8_t s2err = 0;
     frameptr operator()(frameptr fp) {
-      auto* wfptr = reinterpret_cast<dunedaq::rawdata::WIBFrame*>(fp);
+      auto* wfptr = reinterpret_cast<dunedaq::dataformats::WIBFrame*>(fp);
       ;
       return fp;
     }

--- a/src/WIBFrameProcessor.hpp
+++ b/src/WIBFrameProcessor.hpp
@@ -14,7 +14,7 @@
 #include "ReadoutIssues.hpp"
 #include "Time.hpp"
 
-#include "daq-rawdata/wib/WIBFrame.hpp"
+#include "dataformats/wib/WIBFrame.hpp"
 
 #include <functional>
 #include <atomic>
@@ -28,7 +28,7 @@ class WIBFrameProcessor : public TaskRawDataProcessorModel<types::WIB_SUPERCHUNK
 
 public:
   using frameptr = types::WIB_SUPERCHUNK_STRUCT*;
-  using wibframeptr = dunedaq::rawdata::WIBFrame*;
+  using wibframeptr = dunedaq::dataformats::WIBFrame*;
   using funcnode_t = tbb::flow::function_node<frameptr, frameptr>;
 
   explicit WIBFrameProcessor(const std::string& rawtype, std::function<void(frameptr)>& process_override)
@@ -45,7 +45,7 @@ protected:
   stats::counter_t ts_error_ctr_{0};
 
   void timestamp_check(frameptr fp) {
-    auto* wfptr = reinterpret_cast<dunedaq::rawdata::WIBFrame*>(fp);
+    auto* wfptr = reinterpret_cast<dunedaq::dataformats::WIBFrame*>(fp);
     current_ts_ = wfptr->timestamp();
     if (current_ts_ - previous_ts_ != 300) {
       ++ts_error_ctr_;


### PR DESCRIPTION
This PR makes `readout` build against the `dataformats` package instead of `daq-rawdata`. 