### PR TITLE
sbhuller/FakeCardReaderErrors

### DIFF
--- a/src/FileSourceBuffer.hpp
+++ b/src/FileSourceBuffer.hpp
@@ -39,7 +39,7 @@ public:
     // Open file 
     rawdata_ifs_.open(source_filename_, std::ios::in | std::ios::binary);
     if (!rawdata_ifs_) {
-      ers::error(ConfigurationError(ERS_HERE, "Couldn't open binary file."));
+      throw CannotOpenFile(ERS_HERE, source_filename_);
     }
     
     // Check file size 

--- a/src/ReadoutIssues.hpp
+++ b/src/ReadoutIssues.hpp
@@ -30,6 +30,14 @@ namespace dunedaq {
                       " Readout Configuration Error: " << conferror,
                       ((std::string)conferror)) 
 
+    ERS_DECLARE_ISSUE(readout, CannotOpenFile,
+                      " Couldn't open binary file: " << filename,
+                      ((std::string)filename))
+
+    ERS_DECLARE_ISSUE(readout, EmptySourceBuffer,
+                      " Source Buffer is empty, check file: " << filename,
+                      ((std::string)filename))
+
     ERS_DECLARE_ISSUE(readout, QueueTimeoutError,
                       " Readout queue timed out: " << queuename,
                       ((std::string)queuename))


### PR DESCRIPTION
Created two new Issue types in ReadoutIssues.hpp ; CannotOpenFile and EmptySourceBuffer.
Implemented CannotOpenFile issue in FileSourceBuffer.hpp so it is thrown if the binary file couldn't be opened.
CannotOpenFile is catched in FakeCardReader.cpp in do_conf and the issue is thrown and reported as FATAL.
Implemented EmptySourceBuffer in FakeCardReader.cpp in do_start and is reported as FATAL, as well as preventing software from crashing.

fix #23