### PR TITLE
Ron003/logging issue 1 example integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(daq-cmake REQUIRED)
 daq_setup_environment()
 
 find_package(appfwk REQUIRED)
+find_package(logging REQUIRED)
 find_package(dataformats REQUIRED)
 find_package(dfmessages REQUIRED)
 #find_package(udaq_readout_deps REQUIRED)
@@ -16,6 +17,7 @@ find_package(TBB REQUIRED)
 # Dependency sets
 #set(FLXCARD_DEPENDENCIES udaq_readout_deps::FlxCard udaq_readout_deps::cmem_rcc udaq_readout::deps::packetformat)
 set(FLXUTIL_DEPENDENCIES 
+  logging::logging
   dataformats::dataformats
   dfmessages::dfmessages
   #udaq_readout_deps::packetformat 

--- a/plugins/DataLinkHandler.cpp
+++ b/plugins/DataLinkHandler.cpp
@@ -16,7 +16,9 @@
 #include <string>
 #include <vector>
 
-#include <TRACE/trace.h>
+//#include <TRACE/trace.h>
+#include "logging/Logging.hpp"
+
 /**
  * @brief Name used by TRACE TLOG calls from this source file
 */
@@ -39,7 +41,7 @@ DataLinkHandler::DataLinkHandler(const std::string& name)
 void
 DataLinkHandler::init(const data_t& args)
 {
-  ERS_INFO("Initialiyze readout implementation...");
+  TLOG() << "Initialiyze readout implementation...";
   readout_impl_ = createReadout(args, run_marker_);
   if (readout_impl_ == nullptr) {
     throw std::runtime_error("Readout implementation creation failed...");
@@ -49,14 +51,14 @@ DataLinkHandler::init(const data_t& args)
 void
 DataLinkHandler::do_conf(const data_t& args)
 {
-  ERS_INFO("Configure readout implementation...");
+  TLOG() << "Configure readout implementation...";
   readout_impl_->conf(args);
 }
 
 void 
 DataLinkHandler::do_start(const data_t& args)
 {
-  ERS_INFO("Start readout implementeation...");
+  TLOG() << "Start readout implementeation...";
   run_marker_.store(true);
   readout_impl_->start(args);
 }
@@ -64,7 +66,7 @@ DataLinkHandler::do_start(const data_t& args)
 void 
 DataLinkHandler::do_stop(const data_t& args)
 {
-  ERS_INFO("Stop readout implementation...");
+  TLOG() << "Stop readout implementation...";
   run_marker_.store(false);
   readout_impl_->stop(args);
 }

--- a/plugins/DataLinkHandler.cpp
+++ b/plugins/DataLinkHandler.cpp
@@ -6,23 +6,30 @@
  * received with this code.
 */
 #include "readout/datalinkhandler/Nljs.hpp"
-
 #include "DataLinkHandler.hpp"
 
 #include "appfwk/cmd/Nljs.hpp"
+#include "logging/Logging.hpp"
 
 #include <sstream>
 #include <memory>
 #include <string>
 #include <vector>
 
-//#include <TRACE/trace.h>
-#include "logging/Logging.hpp"
-
 /**
  * @brief Name used by TRACE TLOG calls from this source file
 */
 #define TRACE_NAME "DataLinkHandler" // NOLINT
+
+/**
+ * @brief TRACE debug levels used in this source file
+ */
+enum
+{
+  TLVL_ENTER_EXIT_METHODS = 5,
+  TLVL_WORK_STEPS = 10,
+  TLVL_BOOKKEEPING = 15
+};
 
 namespace dunedaq {
 namespace readout { 
@@ -42,7 +49,7 @@ DataLinkHandler::DataLinkHandler(const std::string& name)
 void
 DataLinkHandler::init(const data_t& args)
 {
-  TLOG() << "Initialiyze readout implementation...";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << "Initialiyze readout implementation...";
   readout_impl_ = createReadout(args, run_marker_);
   if (readout_impl_ == nullptr) {
     throw std::runtime_error("Readout implementation creation failed...");
@@ -52,7 +59,7 @@ DataLinkHandler::init(const data_t& args)
 void
 DataLinkHandler::do_conf(const data_t& args)
 {
-  TLOG() << "Configure readout implementation...";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << "Configure readout implementation...";
   readout_impl_->conf(args);
   configured_ = true;
 }
@@ -60,13 +67,13 @@ DataLinkHandler::do_conf(const data_t& args)
 void
 DataLinkHandler::do_scrap(const data_t& /*args*/)
 {
-  ers::info(ers::Message(ERS_HERE,"Scrap readout implementation..."));
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << "Scrap readout implementation...";
   configured_ = false;
 }
 void 
 DataLinkHandler::do_start(const data_t& args)
 {
-  TLOG() << "Start readout implementeation...";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << "Start readout implementeation...";
   run_marker_.store(true);
   readout_impl_->start(args);
 }
@@ -74,7 +81,7 @@ DataLinkHandler::do_start(const data_t& args)
 void 
 DataLinkHandler::do_stop(const data_t& args)
 {
-  TLOG() << "Stop readout implementation...";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << "Stop readout implementation...";
   run_marker_.store(false);
   readout_impl_->stop(args);
 }

--- a/plugins/FakeCardReader.cpp
+++ b/plugins/FakeCardReader.cpp
@@ -5,14 +5,13 @@
  * Licensing/copyright details are in the COPYING file that you should have
  * received with this code.
 */
-
 #include "readout/fakecardreader/Nljs.hpp"
-
 #include "FakeCardReader.hpp"
 #include "ReadoutIssues.hpp"
 #include "ReadoutConstants.hpp"
 
 //#include "dataformats/wib/WIBFrame.hpp"         // FIXME move to dataformats repo
+#include "logging/Logging.hpp"
 #include "readout/WIBFrame.hpp"                   // FIXME now using local copy
 #include "readout/RawWIBTp.hpp"                   // FIXME now using local copy
 #include "appfwk/cmd/Nljs.hpp"
@@ -25,13 +24,20 @@
 #include <string>
 #include <vector>
 
-//#include <TRACE/trace.h>
-#include "logging/Logging.hpp"
-
 /**
  * @brief Name used by TRACE TLOG calls from this source file
 */
 #define TRACE_NAME "FakeCardReader" // NOLINT
+
+/**
+* @brief TRACE debug levels used in this source file
+ */
+enum
+{
+  TLVL_ENTER_EXIT_METHODS = 5,
+  TLVL_WORK_STEPS = 10,
+  TLVL_BOOKKEEPING = 15
+};
 
 namespace dunedaq {
 namespace readout { 
@@ -71,7 +77,7 @@ FakeCardReader::init(const data_t& args)
       throw ResourceQueueError(ERS_HERE, get_name(), qi.name, excpt);
     }
   }
-  ERS_INFO("Init: # output queues: " << output_queues_.size() << "; # tp_output queues: " << tp_output_queues_.size());
+  TLOG() << "Init: # output queues: " << output_queues_.size() << "; # tp_output queues: " << tp_output_queues_.size();
 }
 
 void 
@@ -222,7 +228,7 @@ FakeCardReader::generate_tp_data(appfwk::DAQSink<std::unique_ptr<types::RAW_WIB_
   // This should be changed in case of a generic Fake ELink reader (exercise with TPs dumps)
   int num_elem = tp_source_buffer_->num_elements();
   uint64_t ts_0 = reinterpret_cast<dunedaq::dataformats::RawWIBTp*>(source.data())->get_header()->timestamp();
-  ERS_INFO("First timestamp in the source file: " << ts_0 << "; linkid is: " << linkid);
+  TLOG() << "First timestamp in the source file: " << ts_0 << "; linkid is: " << linkid;
   uint64_t ts_next = ts_0;
 
   dunedaq::dataformats::RawWIBTp* tf{nullptr};
@@ -276,7 +282,7 @@ FakeCardReader::generate_tp_data(appfwk::DAQSink<std::unique_ptr<types::RAW_WIB_
     ++packet_count_;
     rate_limiter.limit();
   }
-  ERS_DEBUG(0, "Data generation thread " << linkid << " finished");
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Data generation thread " << linkid << " finished";
 }
 
 

--- a/src/DefaultRequestHandlerModel.hpp
+++ b/src/DefaultRequestHandlerModel.hpp
@@ -59,7 +59,7 @@ public:
   , occupancy_(0)
   , stats_thread_(0)
   {
-    ers::info(ers::Message(ERS_HERE,"DefaultRequestHandlerModel created..."));
+    TLOG() << "DefaultRequestHandlerModel created...";
     cleanup_request_callback_ = std::bind(&DefaultRequestHandlerModel<RawType>::cleanup_request, 
       this, std::placeholders::_1, std::placeholders::_2);
     data_request_callback_ = std::bind(&DefaultRequestHandlerModel<RawType>::data_request,
@@ -86,7 +86,7 @@ public:
 		<< "auto-pop limit: "<< pop_limit_pct_*100.0f << "% "
 		<< "auto-pop size: " << pop_size_pct_*100.0f  << "% "
 		<< "max requested elements: " << max_requested_elements_;
-	ers::info(ers::Message(ERS_HERE,oss.str()));
+        TLOG() << oss.str();
   }
 
   void start(const nlohmann::json& /*args*/)
@@ -172,7 +172,7 @@ protected:
   }
 
   void run_stats() {
-    ers::info(ers::Message(ERS_HERE,"Statistics thread started..."));
+    TLOG() << "Statistics thread started...";
     int new_pop_reqs = 0;
     int new_pop_count = 0;
     int new_occupancy = 0;
@@ -191,7 +191,7 @@ protected:
       }
       t0 = now;
     }
-	ers::info(ers::Message(ERS_HERE,"Statistics thread stopped..."));
+    TLOG() << "Statistics thread stopped...";
   }
 
   // Data access (LB interfaces)

--- a/src/FileSourceBuffer.hpp
+++ b/src/FileSourceBuffer.hpp
@@ -63,10 +63,8 @@ public:
     rawdata_ifs_.seekg(0, std::ios::beg);
     input_buffer_.reserve(filesize);
     input_buffer_.insert(input_buffer_.begin(), std::istreambuf_iterator<char>(rawdata_ifs_), std::istreambuf_iterator<char>());
-	ers::info( ers::Message(ERS_HERE,"Available elements: "
-	                        +std::to_string( element_count_ )
-	                        +" | In bytes: "
-	                        +std::to_string(input_buffer_.size())));
+    TLOG() << "Available elements: " << std::to_string(element_count_) 
+           << " | In bytes: " << std::to_string(input_buffer_.size());
   }
 
   const int& num_elements() {

--- a/src/FileSourceBuffer.hpp
+++ b/src/FileSourceBuffer.hpp
@@ -9,6 +9,7 @@
 #define UDAQ_READOUT_SRC_FILESOURCEBUFFER_HPP_
 
 #include "ReadoutIssues.hpp"
+#include "logging/Logging.hpp"
 
 #include <fstream>
 
@@ -62,7 +63,10 @@ public:
     rawdata_ifs_.seekg(0, std::ios::beg);
     input_buffer_.reserve(filesize);
     input_buffer_.insert(input_buffer_.begin(), std::istreambuf_iterator<char>(rawdata_ifs_), std::istreambuf_iterator<char>());
-    ERS_INFO("Available elements: " << element_count_ << " | In bytes: " << input_buffer_.size());
+	ers::info( ers::Message(ERS_HERE,"Available elements: "
+	                        +std::to_string( element_count_ )
+	                        +" | In bytes: "
+	                        +std::to_string(input_buffer_.size())));
   }
 
   const int& num_elements() {

--- a/src/FlowGraphRawDataProcessorModel.hpp
+++ b/src/FlowGraphRawDataProcessorModel.hpp
@@ -10,6 +10,7 @@
 #define UDAQ_READOUT_SRC_FLOWGRAPHRAWDATAPROCESSORMODEL_HPP_
 
 #include "RawDataProcessorConcept.hpp"
+#include "logging/Logging.hpp"
 
 #include <functional>
 
@@ -38,7 +39,7 @@ public:
   }
 
   void conf(const nlohmann::json& cfg) {
-    ERS_INFO("Setting up flow grap.");
+	  ers::info(ers::Message(ERS_HERE,"Setting up flow grap."));
     if (!parallel_task_nodes_.empty()){
       for (long unsigned int i=0; i<parallel_task_nodes_.size(); ++i) { // NOLINT
         tbb::flow::make_edge(graph_input_, parallel_task_nodes_[i]);

--- a/src/FlowGraphRawDataProcessorModel.hpp
+++ b/src/FlowGraphRawDataProcessorModel.hpp
@@ -39,7 +39,7 @@ public:
   }
 
   void conf(const nlohmann::json& cfg) {
-	  ers::info(ers::Message(ERS_HERE,"Setting up flow grap."));
+    TLOG() << "Setting up flow grap.";
     if (!parallel_task_nodes_.empty()){
       for (long unsigned int i=0; i<parallel_task_nodes_.size(); ++i) { // NOLINT
         tbb::flow::make_edge(graph_input_, parallel_task_nodes_[i]);

--- a/src/ReadoutModel.hpp
+++ b/src/ReadoutModel.hpp
@@ -96,7 +96,7 @@ public:
    }
     latency_buffer_size_ = conf.latency_buffer_size;
     source_queue_timeout_ms_ = std::chrono::milliseconds(conf.source_queue_timeout_ms);
-    ERS_INFO("ReadoutModel creation for raw type: " << raw_type_name_); 
+    TLOG() << "ReadoutModel creation for raw type: " << raw_type_name_; 
 
     // Instantiate functionalities
     try {

--- a/src/TaskRawDataProcessorModel.hpp
+++ b/src/TaskRawDataProcessorModel.hpp
@@ -10,6 +10,7 @@
 #define UDAQ_READOUT_SRC_ASYNCRAWPROCESSOR_HPP_
 
 #include "RawDataProcessorConcept.hpp"
+#include "logging/Logging.hpp"
 
 #include <functional>
 #include <future>
@@ -37,7 +38,7 @@ public:
   }
 
   void conf(const nlohmann::json& /*cfg*/) {
-    ERS_INFO("Setting up async task tree.");
+    ers::info(ers::Message(ERS_HERE,"Setting up async task tree."));
   }
 
   void process_item(RawType* item) {

--- a/src/TaskRawDataProcessorModel.hpp
+++ b/src/TaskRawDataProcessorModel.hpp
@@ -38,7 +38,7 @@ public:
   }
 
   void conf(const nlohmann::json& /*cfg*/) {
-    ers::info(ers::Message(ERS_HERE,"Setting up async task tree."));
+    TLOG() << "Setting up async task tree.";
   }
 
   void process_item(RawType* item) {

--- a/src/WIBFrameProcessor.hpp
+++ b/src/WIBFrameProcessor.hpp
@@ -13,9 +13,9 @@
 #include "ReadoutStatistics.hpp"
 #include "ReadoutIssues.hpp"
 #include "Time.hpp"
-#include "logging/Logging.hpp"
 
 #include "dataformats/wib/WIBFrame.hpp"
+#include "logging/Logging.hpp"
 
 #include <functional>
 #include <atomic>
@@ -54,10 +54,8 @@ protected:
         first_ts_missmatch_ = false;
       }
       else {
-		  ers::info(ers::Message(ERS_HERE,
-		                         "Timestamp MISSMATCH! -> | previous: "
-		                         +std::to_string(previous_ts_)
-		                         +" next: "+std::to_string(current_ts_)));
+        TLOG() << "Timestamp MISSMATCH! -> | previous: " << std::to_string(previous_ts_) 
+               << " next: "+std::to_string(current_ts_);
       }
     }
     previous_ts_ = current_ts_;

--- a/src/WIBFrameProcessor.hpp
+++ b/src/WIBFrameProcessor.hpp
@@ -13,6 +13,7 @@
 #include "ReadoutStatistics.hpp"
 #include "ReadoutIssues.hpp"
 #include "Time.hpp"
+#include "logging/Logging.hpp"
 
 #include "dataformats/wib/WIBFrame.hpp"
 
@@ -53,7 +54,10 @@ protected:
         first_ts_missmatch_ = false;
       }
       else {
-        ERS_INFO("Timestamp MISSMATCH! -> | previous: " << previous_ts_ << " next: " << current_ts_);
+		  ers::info(ers::Message(ERS_HERE,
+		                         "Timestamp MISSMATCH! -> | previous: "
+		                         +std::to_string(previous_ts_)
+		                         +" next: "+std::to_string(current_ts_)));
       }
     }
     previous_ts_ = current_ts_;

--- a/src/WIBRequestHandler.hpp
+++ b/src/WIBRequestHandler.hpp
@@ -37,7 +37,7 @@ public:
   : DefaultRequestHandlerModel<types::WIB_SUPERCHUNK_STRUCT>(rawtype, marker,
       occupancy_callback, read_callback, pop_callback, front_callback, fragment_sink)
   {
-    ers::info(ers::Message(ERS_HERE,"WIBRequestHandler created..."));
+    TLOG() << "WIBRequestHandler created...";
     data_request_callback_ = std::bind(&WIBRequestHandler::tpc_data_request, 
       this, std::placeholders::_1, std::placeholders::_2);
   } 
@@ -140,7 +140,7 @@ protected:
         << "ElementsInWindow=" << num_elements_in_window << " "
         << "MinNumElements=" << min_num_elements << " "
         << "Occupancy=" << occupancy_guess;
-	  ers::info(ers::Message(ERS_HERE,oss.str()));
+      TLOG() << oss.str();
     } else {
       //auto fromheader = *(reinterpret_cast<const dataformats::WIBHeader*>(front_callback_(num_element_offset)));
       for (uint_fast32_t idxoffset=0; idxoffset<num_elements_in_window; ++idxoffset) {


### PR DESCRIPTION
I have or will have PRs in for the ron003/logging_issue_1_example_integration branch in 6 packages:
- appfwk
- dfmodules
- ipm
- networkqueue
- readout
- trigemu

With these packages on the ron003/logging_issue_1_example_integration branch, along with the other develop
branches for cmdlib, daq-cmake, dataformats, dfmessages, logging restcmd, serialization packages as of
16 feb and with adjustments to the dunedaq-v2.2.0 development environment:

```
sed -i 's/v4_3_1b e19/v4_3_1c e19:prof/' dbt-settings
for pp in "msgpack_c v3_3_0 e19:prof" "cppzmq v4_3_0 e19:prof";do
  grep "$pp" dbt-settings || sed -ie "/zmq/a \
    \"$pp\"
" dbt-settings
done

sed -i 's/"dataformats"/"serialization" "networkqueue" "dataformats"/' sourcecode/dbt-build-order.cmake
```

Then, the minidaq demonstration works.

Other changes still need to be made as indicated (not exhaustively) by the output of
`find sourcecode -type f | xargs egrep 'ERS_(INFO|LOG|DEBUG)'`
