### PR TITLE
Added configurable first DAQ timestamp.

### DIFF
--- a/plugins/FakeCardReader.cpp
+++ b/plugins/FakeCardReader.cpp
@@ -140,7 +140,10 @@ FakeCardReader::generate_data(appfwk::DAQSink<std::unique_ptr<types::WIB_SUPERCH
   // This should be changed in case of a generic Fake ELink reader (exercise with TPs dumps)
   int num_elem = source_buffer_->num_elements();
   auto wfptr = reinterpret_cast<dunedaq::dataformats::WIBFrame*>(source.data());
-  uint64_t ts_0 = wfptr->get_wib_header()->get_timestamp();
+  
+  // set the initial timestamp to a configured value, otherwise just use the timestamp from the wib header
+  uint64_t ts_0 = (cfg_.set_t0_to >= 0) ? cfg_.set_t0_to : wfptr->get_wib_header()->get_timestamp();
+  
   ERS_INFO("First timestamp in the source file: " << ts_0 << "; linkid is: " << linkid);
   uint64_t ts_next = ts_0;
 

--- a/schema/fakereadout-app.jsonnet
+++ b/schema/fakereadout-app.jsonnet
@@ -35,7 +35,8 @@ local qspec_list = [
         "rate_khz": 166,
         "raw_type": "wib",
         "data_filename": "/tmp/frames.bin",
-        "queue_timeout_ms": 2000
+        "queue_timeout_ms": 2000,
+        "set_t0_t0": -1
       }
       ),
       cmd.mcmd("fake-handler", {

--- a/schema/readout-FakeCardReader-make.jsonnet
+++ b/schema/readout-FakeCardReader-make.jsonnet
@@ -4,12 +4,13 @@
     queue: "fake-elink"
 
     // Make a conf object for cardreader
-    conf(lid=0, inplim=10485100, rate=166, rawtype="wib", datfile="/tmp/frames.bin", qtms=2000) :: {
+    conf(lid=0, inplim=10485100, rate=166, rawtype="wib", datfile="/tmp/frames.bin", qtms=2000, st0=-1) :: {
         link_ids: [lid],
         input_limit: inplim, 
         rate_khz: rate, 
         data_filename: datfile, 
-        queue_timeout_ms: qtms
+        queue_timeout_ms: qtms,
+        set_t0_to: st0
     },
 }
 

--- a/schema/readout-FakeCardReader-schema.jsonnet
+++ b/schema/readout-FakeCardReader-schema.jsonnet
@@ -16,6 +16,9 @@ local fakecardreader = {
     uint4  : s.number("uint4", "u4",
                      doc="An unsigned of 4 bytes"),
 
+    int8  : s.number("int8", "i8",
+                     doc="integer of 8 bytes"),
+
     khz  : s.number("khz", "f8",
                      doc="A frequency in kHz"),
   
@@ -49,6 +52,9 @@ local fakecardreader = {
 
         s.field("queue_timeout_ms", self.uint4, 2000,
                 doc="Queue timeout in milliseconds"),
+        
+        s.field("set_t0_to", self.int8, -1,
+                doc="The first DAQ timestamp"),
 
     ], doc="Fake Elink reader module configuration"),
 

--- a/schema/readout-FakeCardReader-schema.jsonnet
+++ b/schema/readout-FakeCardReader-schema.jsonnet
@@ -54,7 +54,7 @@ local fakecardreader = {
                 doc="Queue timeout in milliseconds"),
         
         s.field("set_t0_to", self.int8, -1,
-                doc="The first DAQ timestamp"),
+                doc="The first DAQ timestamp. If -1, t0 from file is used."),
 
     ], doc="Fake Elink reader module configuration"),
 


### PR DESCRIPTION
Introduced set_t0_to variable in readout-FakeCardReader-schema.jsonnet
Modified FakeCardReader.cpp to use the new set_t0_to variable

By default set_t0_to is set to -1 and FakeCardReader.cpp will use the timestamp from the wib header if the value of set_t0_to is negative, otherwise, it will set ts_0 = set_t0_to.

fixes #27 