### PR TITLE
Hristova/fix lint errors

### DIFF
--- a/include/readout/RawWIBTp.hpp
+++ b/include/readout/RawWIBTp.hpp
@@ -5,8 +5,8 @@
  * Licensing/copyright details are in the COPYING file that you should have
  * received with this code.
  */
-#ifndef DATAFORMATS_INCLUDE_DATAFORMATS_WIB_RAWWIBTP_HPP_
-#define DATAFORMATS_INCLUDE_DATAFORMATS_WIB_RAWWIBTP_HPP_
+#ifndef READOUT_INCLUDE_READOUT_RAWWIBTP_HPP_
+#define READOUT_INCLUDE_READOUT_RAWWIBTP_HPP_
 
 #include <bitset>
 #include <iostream>
@@ -15,53 +15,64 @@
 namespace dunedaq {
 namespace dataformats {
 
-typedef uint32_t word_t;
+using tp_word_t = uint32_t; // NOLINT(build/unsigned)
 
 //===================
 // TP header struct
 //===================
 struct TpHeader
 {
-  word_t flags: 13, slot_no: 3, wire_no : 8, fiber_no : 3, crate_no : 5;
-  word_t timestamp_1;
-  word_t timestamp_2;
+  tp_word_t m_flags: 13, m_slot_no: 3, m_wire_no : 8, m_fiber_no : 3, m_crate_no : 5;
+  tp_word_t m_timestamp_1;
+  tp_word_t m_timestamp_2;
 
-  uint64_t timestamp() const
+  uint64_t get_timestamp() const  // NOLINT(build/unsigned)
   {
-    uint64_t timestamp = timestamp_1 | (timestamp_2 << 32);
+    uint64_t timestamp = static_cast<uint64_t>(m_timestamp_1) | (static_cast<int64_t>(m_timestamp_2) << 32);  // NOLINT(build/unsigned)
     return timestamp;
   }
 
-  void set_timestamp(const uint64_t new_timestamp)
+  void set_timestamp(const uint64_t new_timestamp)  // NOLINT(build/unsigned)
   {
-    timestamp_1 = new_timestamp;
-    timestamp_2 = new_timestamp >> 32;
+    m_timestamp_1 = new_timestamp;
+    m_timestamp_2 = new_timestamp >> 32;
   }
 
   // Print functions for debugging.
-  void print() const
+  std::ostream& print(std::ostream& o) const
   {
-    std::cout << "flags:" << unsigned(flags) << " slot:" << unsigned(slot_no) << " wire:" << unsigned(wire_no) 
-              << " fiber:" << unsigned(fiber_no) << " crate:" << unsigned(crate_no)
-              << " timestamp:" << timestamp()
-              << '\n';
+    o << "flags:" << unsigned(m_flags) << " slot:" << unsigned(m_slot_no) << " wire:" << unsigned(m_wire_no) 
+      << " fiber:" << unsigned(m_fiber_no) << " crate:" << unsigned(m_crate_no)
+      << " timestamp:" << get_timestamp();
+    return o  << '\n';
   }
 
-  void printHex() const
+  std::ostream& print_hex(std::ostream& o) const
   {
-    std::cout << "Printing raw WIB TP header:\n";
-    std::cout << std::hex << "flags:" << flags << " slot:" << slot_no << " wire:" << wire_no
-              << " fiber:" << fiber_no << " crate:" << crate_no << " timestamp:" << timestamp() << std::dec << '\n';
+    o << "Printing raw WIB TP header:\n";
+    o << std::hex << "flags:" << m_flags << " slot:" << m_slot_no << " wire:" << m_wire_no
+      << " fiber:" << m_fiber_no << " crate:" << m_crate_no << " timestamp:" << get_timestamp(); 
+    return o << std::dec << '\n';
   }
 
-  void printBits() const
+  std::ostream& print_bits(std::ostream& o) const
   {
-    std::cout << "flags:" << std::bitset<13>(flags)
-              << " slot:" << std::bitset<3>(slot_no) << " wire:" << std::bitset<8>(wire_no)
-              << " fiber:" << std::bitset<3>(fiber_no) << " crate:" << std::bitset<5>(crate_no) 
-              << " timestamp: " << timestamp() << '\n';
+    return o << "flags:" << std::bitset<13>(m_flags)
+             << " slot:" << std::bitset<3>(m_slot_no) << " wire:" << std::bitset<8>(m_wire_no)
+             << " fiber:" << std::bitset<3>(m_fiber_no) << " crate:" << std::bitset<5>(m_crate_no) 
+             << " timestamp: " << get_timestamp() << '\n';
   }
 };
+
+inline std::ostream&
+operator<<(std::ostream& o, TpHeader const& h)
+{
+  return o << "flags:" << std::bitset<13>(h.m_flags)
+           << " slot:" << std::bitset<3>(h.m_slot_no) << " wire:" << std::bitset<8>(h.m_wire_no)
+           << " fiber:" << std::bitset<3>(h.m_fiber_no) << " crate:" << std::bitset<5>(h.m_crate_no) 
+           << " timestamp: " << h.get_timestamp() << '\n';
+}
+
 
 //========================
 // TP data struct
@@ -70,28 +81,38 @@ struct TpData
 {
   // This struct contains three words of TP values that form the main repeating
   // pattern in the TP block.
-  word_t end_time: 16, start_time: 16;
-  word_t peak_time: 16, peak_adc: 16;
-  word_t hit_continue: 1, flags: 15, sum_adc: 16;
+  tp_word_t m_end_time: 16, m_start_time: 16;
+  tp_word_t m_peak_time: 16, m_peak_adc: 16;
+  tp_word_t m_hit_continue: 1, m_flags: 15, m_sum_adc: 16;
 
-  void print() const
+  std::ostream& print(std::ostream& o) const
   {
-    std::cout << "end_time:" << unsigned(end_time) << " start_time:" << unsigned(start_time)
-              << " peak_time:" << unsigned(peak_time) << " peak_adc:" << unsigned(peak_adc)
-              << " hit_continue:" << unsigned(hit_continue) << " flags:" << unsigned(flags) 
-              << " sum_adc:" << unsigned(sum_adc) 
-              << '\n';
+    return o << "end_time:" << unsigned(m_end_time) << " start_time:" << unsigned(m_start_time)
+           << " peak_time:" << unsigned(m_peak_time) << " peak_adc:" << unsigned(m_peak_adc)
+           << " hit_continue:" << unsigned(m_hit_continue) << " flags:" << unsigned(m_flags) 
+           << " sum_adc:" << unsigned(m_sum_adc) 
+           << '\n';
   }
 
-  void printHex(const int& i) const
+  std::ostream& print_hex(std::ostream& o) const
   {
-    std::cout << "Printing raw WIB TP " << i << ":\n";
-    std::cout << std::hex << "end_time:" << end_time << " start_time:" << start_time 
-              << " peak_time:" << peak_time << " peak_adc:" << peak_adc 
-              << " hit_continue:" << hit_continue << " flags:" << flags 
-              << " sum_adc:" << sum_adc << std::dec << '\n';
+    return o << std::hex << "end_time:" << m_end_time << " start_time:" << m_start_time 
+              << " peak_time:" << m_peak_time << " peak_adc:" << m_peak_adc 
+              << " hit_continue:" << m_hit_continue << " flags:" << m_flags 
+              << " sum_adc:" << m_sum_adc << std::dec << '\n';
   }
 };
+
+inline std::ostream&
+operator<<(std::ostream& o, TpData const& tp)
+{
+  return o << "end_time:" << unsigned(tp.m_end_time) << " start_time:" << unsigned(tp.m_start_time)
+           << " peak_time:" << unsigned(tp.m_peak_time) << " peak_adc:" << unsigned(tp.m_peak_adc)
+           << " hit_continue:" << unsigned(tp.m_hit_continue) << " flags:" << unsigned(tp.m_flags)
+           << " sum_adc:" << unsigned(tp.m_sum_adc)
+           << '\n';
+}
+
 
 //========================
 // TP pedestal information struct
@@ -99,24 +120,37 @@ struct TpData
 struct TpPedinfo
 {
   // This struct contains three words: one carrying median and accumulator and two padding words
-  word_t accumulator: 16, median: 16;
-  word_t padding_2: 16, padding_1: 16;
-  word_t padding_4: 16, padding_3: 16;
+  tp_word_t m_accumulator: 16, m_median: 16;
+  tp_word_t m_padding_2: 16, m_padding_1: 16;
+  tp_word_t m_padding_4: 16, m_padding_3: 16;
 
-  void print() const 
+  std::ostream& print(std::ostream& o) const 
   {
-    std::cout << "median:" << unsigned(median) << " accumulator:" << unsigned(accumulator)
-              << '\n';
+    return o << "median:" << unsigned(m_median) << " accumulator:" << unsigned(m_accumulator)
+             << " padding_1:" << m_padding_1 << " padding_2:" << m_padding_2
+             << " padding_3: "<< m_padding_3 << " padding_4:" << m_padding_4
+             << '\n';
   }
 
-  void printHex() const
+  std::ostream& print_hex(std::ostream& o) const
   {
-    std::cout << "Printing raw WIB TP pedinfo:\n";
-    std::cout << std::hex << "median:" << median << " accumulator:" << accumulator 
-              << " padding_1:" << padding_1 << " padding_2:" << padding_2 
-              << " padding_3: "<< padding_3 << " padding_4:" << padding_4 << std::dec << '\n';
+    o << "Printing raw WIB TP pedinfo:\n";
+    o << std::hex << "median:" << m_median << " accumulator:" << m_accumulator 
+      << " padding_1:" << m_padding_1 << " padding_2:" << m_padding_2 
+      << " padding_3: "<< m_padding_3 << " padding_4:" << m_padding_4;
+    return o << std::dec << '\n';
   }
 };
+
+inline std::ostream&
+operator<<(std::ostream& o, TpPedinfo const& p)
+{
+  return o << "median:" << unsigned(p.m_median) << " accumulator:" << unsigned(p.m_accumulator)
+           << " padding_1:" << p.m_padding_1 << " padding_2:" << p.m_padding_2
+           << " padding_3: "<< p.m_padding_3 << " padding_4:" << p.m_padding_4
+           << '\n';
+}
+
 
 //========================
 // TpData block
@@ -145,23 +179,39 @@ struct TpDataBlock
     return block.size();
   }
 
-  void print() const 
+  std::ostream& print(std::ostream& o) const
   {
     for (auto b : block) {
-      b.print();
+      o << b;
     }
+    return o;
   }
 
-  void printHex() const
+  std::ostream& print_hex(std::ostream& o) const
   {
     int i=0;
-    std::cout << "Printing raw WIB TP data block:\n";
+    o << "Printing raw WIB TP data block:\n";
     for (auto b: block) {
-      b.printHex(i+1);
+      o << "Printing raw WIB TP " << i << ":\n";
+      o << b;
       ++i;
     }
+    return o;
   }
 };
+
+inline std::ostream&
+operator<<(std::ostream& o, TpDataBlock const& db)
+{
+   int i=0;
+    o << "Printing raw WIB TP data block:\n";
+    for (auto b: db.block) {
+      o << "Printing raw WIB TP " << i << ":\n";
+      o << b;
+      ++i;
+    }
+    return o;
+}
 
 //=============
 // Raw WIB Trigger Primitive frame
@@ -174,62 +224,55 @@ public:
   static constexpr size_t m_num_tp_words = 3;
   static constexpr size_t m_num_pedinfo_words = 3;
 
-private:
-  TpHeader head;
-  TpData tp;
-  TpDataBlock data;
-  TpPedinfo pedinfo;
-
-public:
   // TP header accessors
-  uint8_t slot_no() const { return head.slot_no; }
-  uint8_t wire_no() const { return head.wire_no; }
-  uint8_t fiber_no() const { return head.fiber_no; }
-  uint8_t crate_no() const { return head.crate_no; }
-  uint64_t timestamp() const { return head.timestamp(); }
+  uint8_t slot_no() const { return m_head.m_slot_no; }           // NOLINT(build/unsigned)
+  uint8_t wire_no() const { return m_head.m_wire_no; }           // NOLINT(build/unsigned)
+  uint8_t fiber_no() const { return m_head.m_fiber_no; }         // NOLINT(build/unsigned)
+  uint8_t crate_no() const { return m_head.m_crate_no; }         // NOLINT(build/unsigned)
+  uint64_t timestamp() const { return m_head.get_timestamp(); }  // NOLINT(build/unsigned)
   // TP header mutators
-  void set_slot_no(const uint8_t new_slot_no) { head.slot_no = new_slot_no; }
-  void set_wire_no(const uint8_t new_wire_no) { head.wire_no = new_wire_no; }
-  void set_fiber_no(const uint8_t new_fiber_no) { head.fiber_no = new_fiber_no; }
-  void set_crate_no(const uint8_t new_crate_no) { head.crate_no = new_crate_no; }
-  void set_timestamp(uint64_t new_timestamp) { head.set_timestamp(new_timestamp); }
+  void set_slot_no(const uint8_t new_slot_no) { m_head.m_slot_no = new_slot_no; }      // NOLINT(build/unsigned)
+  void set_wire_no(const uint8_t new_wire_no) { m_head.m_wire_no = new_wire_no; }      // NOLINT(build/unsigned)
+  void set_fiber_no(const uint8_t new_fiber_no) { m_head.m_fiber_no = new_fiber_no; }  // NOLINT(build/unsigned)
+  void set_crate_no(const uint8_t new_crate_no) { m_head.m_crate_no = new_crate_no; }  // NOLINT(build/unsigned)
+  void set_timestamp(uint64_t new_timestamp) { m_head.set_timestamp(new_timestamp); }  // NOLINT(build/unsigned)
 
   // TP data accessors
-  int num_tp_per_block() const { return data.num_tp_per_block(); }
+  int num_tp_per_block() const { return m_data.num_tp_per_block(); }
   // TP data mutators
 
   // Const struct accessors
-  const TpHeader*     get_header() const { return &head; }
-  const TpData*       get_tp(const int& tp_num) const { return data.get_tp(tp_num); }
-  const TpDataBlock*  get_data() const { return &data; }
-  const TpPedinfo*    get_pedinfo() const { return &pedinfo; }
-  size_t get_data_size() const { return data.get_data_size(); }
+  const TpHeader*     get_header() const { return &m_head; }
+  const TpData*       get_tp(const int& tp_num) const { return m_data.get_tp(tp_num); }
+  const TpDataBlock*  get_data() const { return &m_data; }
+  const TpPedinfo*    get_pedinfo() const { return &m_pedinfo; }
+  size_t get_data_size() const { return m_data.get_data_size(); }
   // Const struct mutators
-  void set_header(const TpHeader& hdr) { head = hdr; }
-  void set_tp(const TpData& tpdata) { data.set_tp(tpdata); }
-  void set_data(const TpDataBlock& block) {data = block; }
-  void set_pedinfo(const TpPedinfo& ped) { pedinfo = ped; }
+  void set_header(const TpHeader& hdr) { m_head = hdr; }
+  void set_tp(const TpData& tpdata) { m_data.set_tp(tpdata); }
+  void set_data(const TpDataBlock& block) {m_data = block; }
+  void set_pedinfo(const TpPedinfo& ped) { m_pedinfo = ped; }
 
-  // Utility functions
-  void print() const
-  {
-    std::cout << "Printing raw WIB TP frame:\n";
-    head.print();
-    data.print();
-    pedinfo.print();  
-  }
+  friend std::ostream& operator<<(std::ostream& o, RawWIBTp const& rwtp);
 
-  void printHex() const 
-  {
-    std::cout << "Printing raw WIB TP frame:\n";
-    head.printHex();
-    data.printHex();
-    pedinfo.printHex();
-  }
+private:
+  TpHeader m_head;
+  TpDataBlock m_data;
+  TpPedinfo m_pedinfo;
 };
+
+inline std::ostream&
+operator<<(std::ostream& o, RawWIBTp const& rwtp)
+{
+  o << "Printing raw WIB TP:" << '\n';
+  o << rwtp.m_head << '\n';
+  o << rwtp.m_data << '\n';
+  o << rwtp.m_pedinfo << '\n';
+  return o;
+}
 
 
 } // namespace dataformats
 } // namespace dunedaq
 
-#endif // DATAFORMATS_INCLUDE_DATAFORMATS_WIB_WIBFRAME_HPP_
+#endif // READOUT_INCLUDE_READOUT_RAWWIBTP_HPP_

--- a/plugins/FakeCardReader.cpp
+++ b/plugins/FakeCardReader.cpp
@@ -254,7 +254,7 @@ FakeCardReader::generate_tp_data(appfwk::DAQSink<std::unique_ptr<types::RAW_WIB_
 
   // This should be changed in case of a generic Fake ELink reader (exercise with TPs dumps)
   int num_elem = m_tp_source_buffer->num_elements();
-  uint64_t ts_0 = reinterpret_cast<dunedaq::dataformats::RawWIBTp*>(source.data())->get_header()->timestamp(); // NOLINT
+  uint64_t ts_0 = reinterpret_cast<dunedaq::dataformats::RawWIBTp*>(source.data())->get_header()->get_timestamp(); // NOLINT
   TLOG() << "First timestamp in the source file: " << ts_0 << "; linkid is: " << linkid;
   uint64_t ts_next = ts_0; // NOLINT
 


### PR DESCRIPTION
This PR is for adding to the `develop` branch the fixes which remove the `lint` errors from the newly added `RawWIBTp.hpp` format. It also fixes a compiler warning related to the 64-bit timestamp. 