### PR TITLE
Fixed config generation

### DIFF
--- a/python/readout/app_confgen.py
+++ b/python/readout/app_confgen.py
@@ -127,18 +127,16 @@ def generate(
     jstr = json.dumps(startcmd.pod(), indent=4, sort_keys=True)
     print("="*80+"\nStart\n\n", jstr)
 
-    emptypars = rccmd.EmptyParams()
-
     stopcmd = mrccmd("stop", "RUNNING", "CONFIGURED", [
-            ("fake_source", emptypars),
-            ("datahandler_.*", emptypars),
+            ("fake_source", None),
+            ("datahandler_.*", None),
         ])
 
     jstr = json.dumps(stopcmd.pod(), indent=4, sort_keys=True)
     print("="*80+"\nStop\n\n", jstr)
 
     scrapcmd = mrccmd("scrap", "CONFIGURED", "INITIAL", [
-            ("", emptypars)
+            ("", None)
         ])
 
     jstr = json.dumps(scrapcmd.pod(), indent=4, sort_keys=True)


### PR DESCRIPTION
Changed empty params to None as EmptyParams was removed from rcif.
closes #57 