### PR TITLE
Check if cleanup was already requested before requesting it again

### DIFF
--- a/src/DefaultRequestHandlerModel.hpp
+++ b/src/DefaultRequestHandlerModel.hpp
@@ -137,11 +137,12 @@ public:
   {
     //TLOG_DEBUG(TLVL_WORK_STEPS) << "Enter auto_cleanup_check";
     auto size_guess = m_occupancy_callback();
-    if (size_guess > m_pop_limit_size) {
+    if (!m_cleanup_requested && size_guess > m_pop_limit_size) {
       dfmessages::DataRequest dr;
       auto delay_us = 0;
       auto execfut = std::async(std::launch::deferred, m_cleanup_request_callback, dr, delay_us);
-      m_completion_queue.push(std::move(execfut));              
+      m_completion_queue.push(std::move(execfut));
+      m_cleanup_requested = true;
     }
   }
 
@@ -181,6 +182,7 @@ protected:
       m_occupancy = m_occupancy_callback();
       m_pops_count.store(m_pops_count.load()+to_pop);
     }
+    m_cleanup_requested = false;
     return RequestResult(ResultCode::kCleanup, dr);
   }
 
@@ -290,6 +292,8 @@ private:
   stats::counter_t m_pops_count;
   stats::counter_t m_occupancy;
   ReusableThread m_stats_thread;
+
+  std::atomic<bool> m_cleanup_requested = false;
 
 };
 


### PR DESCRIPTION
Check if cleanup was already requested. Otherwise the consumer thread processing data from the wib-links will create new futures as long as the first cleanup request was not completed yet. 