### PR TITLE
Avoid race condition in latency buffer cleanup

### DIFF
--- a/src/DefaultRequestHandlerModel.hpp
+++ b/src/DefaultRequestHandlerModel.hpp
@@ -126,9 +126,12 @@ public:
     if (!m_cleanup_requested && size_guess > m_pop_limit_size) {
       dfmessages::DataRequest dr;
       auto delay_us = 0;
+      // 10-May-2021, KAB: moved the assignment of m_cleanup_requested so that is is *before* the creation of
+      // the future and the addition of the future to the completion queue in order to avoid the race condition
+      // in which the future gets run before we have a chance to set the m_cleanup_requested flag here.
+      m_cleanup_requested = true;
       auto execfut = std::async(std::launch::deferred, &DefaultRequestHandlerModel<RawType, LatencyBufferType>::cleanup_request, this, dr, delay_us);
       m_completion_queue.enqueue(std::move(execfut));
-      m_cleanup_requested = true;
     }
   }
 


### PR DESCRIPTION
When running tests of a system with 3 Readout Apps and 5 links per app, I noticed occasional problems in which the expected number of events did not show up in the output HDF5 file.  I traced this to a situation in which the latency buffer of one of the links filled up.  And, I believe that the latency buffer filling up was caused by a race condition.  Basically, the m_cleanup_requested data member was set to true *after* the cleanup was run, and every test of the latency buffer size after that was skipped because it seemed like a cleanup was already pending, but it was not.

Here are the commands that I used to create the system configuration and run tests:

- `python -m minidaqapp.nanorc.mdapp_multiru_gen --host-ru localhost --host-ru localhost --host-ru localhost -d /scratch/biery/data/frames.bin -o . -s 10 -n 5 --enable-trace mdapp_6proc`
- `export tmprun=51061600; nanorc mdapp_6proc boot init conf start ${tmprun} wait 2 resume wait 120 pause wait 1 stop wait 1 start ${tmprun} resume wait 120 stop wait 1 start ${tmprun} resume wait 120 pause stop wait 1 start ${tmprun} resume wait 120 stop wait 1 scrap terminate`

Here are the sizes of the 8 data files that I created before the code change (two sets of 4 runs each):

```
-rw-r--r-- 1 biery mu2e 41281328 May 10 15:30 swtest_run51061528_0000_biery_20210510T202830.hdf5
-rw-r--r-- 1 biery mu2e 34177224 May 10 15:32 swtest_run51061528_0000_biery_20210510T203038.hdf5
-rw-r--r-- 1 biery mu2e  7123256 May 10 15:34 swtest_run51061528_0000_biery_20210510T203243.hdf5
-rw-r--r-- 1 biery mu2e  9538448 May 10 15:36 swtest_run51061528_0000_biery_20210510T203448.hdf5
-rw-r--r-- 1 biery mu2e 12850056 May 10 15:39 swtest_run51061537_0000_biery_20210510T203719.hdf5
-rw-r--r-- 1 biery mu2e  7123608 May 10 15:41 swtest_run51061537_0000_biery_20210510T203927.hdf5
-rw-r--r-- 1 biery mu2e  9669504 May 10 15:43 swtest_run51061537_0000_biery_20210510T204132.hdf5
```

Here are the file sizes of the 12 runs that I took after the code change (note the more consisten results):

```
-rw-r--r-- 1 biery mu2e 41282368 May 10 15:55 swtest_run51061553_0000_biery_20210510T205344.hdf5
-rw-r--r-- 1 biery mu2e 41434248 May 10 15:57 swtest_run51061553_0000_biery_20210510T205552.hdf5
-rw-r--r-- 1 biery mu2e 41193344 May 10 16:00 swtest_run51061553_0000_biery_20210510T205757.hdf5
-rw-r--r-- 1 biery mu2e 41624600 May 10 16:02 swtest_run51061553_0000_biery_20210510T210003.hdf5
-rw-r--r-- 1 biery mu2e 41282368 May 10 16:05 swtest_run51061603_0000_biery_20210510T210314.hdf5
-rw-r--r-- 1 biery mu2e 41513920 May 10 16:07 swtest_run51061603_0000_biery_20210510T210522.hdf5
-rw-r--r-- 1 biery mu2e 41281944 May 10 16:09 swtest_run51061603_0000_biery_20210510T210727.hdf5
-rw-r--r-- 1 biery mu2e 41514976 May 10 16:11 swtest_run51061603_0000_biery_20210510T210932.hdf5
-rw-r--r-- 1 biery mu2e 41282368 May 10 16:14 swtest_run51061612_0000_biery_20210510T211214.hdf5
-rw-r--r-- 1 biery mu2e 41625848 May 10 16:16 swtest_run51061612_0000_biery_20210510T211421.hdf5
-rw-r--r-- 1 biery mu2e 41282368 May 10 16:18 swtest_run51061612_0000_biery_20210510T211626.hdf5
-rw-r--r-- 1 biery mu2e 41514072 May 10 16:20 swtest_run51061612_0000_biery_20210510T211832.hdf5
```