### PR TITLE
Added TRACE message when pushing Fragments onto the output queue

### DIFF
--- a/include/readout/models/DefaultRequestHandlerModel.hpp
+++ b/include/readout/models/DefaultRequestHandlerModel.hpp
@@ -38,6 +38,7 @@
 #include <vector>
 
 using dunedaq::readout::logging::TLVL_HOUSEKEEPING;
+using dunedaq::readout::logging::TLVL_QUEUE_PUSH;
 using dunedaq::readout::logging::TLVL_WORK_STEPS;
 
 namespace dunedaq {
@@ -168,6 +169,10 @@ public:
       if (result.result_code == ResultCode::kFound) {
         // Push to Fragment queue
         try {
+          TLOG_DEBUG(TLVL_QUEUE_PUSH) << "Sending fragment with trigger_number "
+                                      << result.fragment->get_trigger_number() << ", run number "
+                                      << result.fragment->get_run_number() << ", and GeoID "
+                                      << result.fragment->get_element_id();
           m_fragment_sink->push(std::move(result.fragment));
         } catch (const ers::Issue& excpt) {
           std::ostringstream oss;

--- a/include/readout/models/SourceEmulatorModel.hpp
+++ b/include/readout/models/SourceEmulatorModel.hpp
@@ -31,7 +31,6 @@
 #include <utility>
 #include <vector>
 
-using dunedaq::readout::logging::TLVL_QUEUE_POP;
 using dunedaq::readout::logging::TLVL_TAKE_NOTE;
 using dunedaq::readout::logging::TLVL_WORK_STEPS;
 


### PR DESCRIPTION
I recall that we had a similar message before the code re-organization, and I was hoping that we could get it back.
Please let me know if this seems reasonable.
Thanks,
Kurt