### PR TITLE
Set the Fragment sequence_number from the DataRequest sequenceNumber

### DIFF
--- a/include/readout/models/DefaultRequestHandlerModel.hpp
+++ b/include/readout/models/DefaultRequestHandlerModel.hpp
@@ -213,6 +213,7 @@ protected:
     fh.window_begin = dr.window_begin;
     fh.window_end = dr.window_end;
     fh.run_number = dr.run_number;
+    fh.sequence_number = dr.sequence_number;
     fh.element_id = { m_geoid.system_type, m_geoid.region_id, m_geoid.element_id };
     fh.fragment_type = static_cast<dataformats::fragment_type_t>(ReadoutType::fragment_type);
     return std::move(fh);


### PR DESCRIPTION
Now that the addition of a sequence_number field to various data structures has been merged to the _develop_ branches in the _dataformats and dfmessages_ repositories, I believe that we can add the use of that field to the _readout_ code.

This PR is for the _readout_ code change that I believe does this.  Of course, it would be great for someone to double-check that my change makes sense.

I've tested this change with the changes in other repositories and successfully written some fake data with a long readout window.