### PR TITLE
remove unneeded conversion to ns

### DIFF
--- a/include/readout/NDReadoutTypes.hpp
+++ b/include/readout/NDReadoutTypes.hpp
@@ -37,7 +37,7 @@ struct PACMAN_MESSAGE_STRUCT
   {
     auto thisptr = reinterpret_cast<const dunedaq::dataformats::PACMANFrame*>(&data);  // NOLINT
     auto otherptr = reinterpret_cast<const dunedaq::dataformats::PACMANFrame*>(&other.data);  // NOLINT
-    return (thisptr->get_msg_header((void *) &data)->unix_ts) * 1000000000 < (otherptr->get_msg_header((void *) &other.data)->unix_ts) * 1000000000 ? true : false;  // NOLINT
+    return (thisptr->get_msg_header((void *) &data)->unix_ts) < (otherptr->get_msg_header((void *) &other.data)->unix_ts) ? true : false;  // NOLINT
   }
 
   // message UNIX timestamp - NOT individual packet timestamps


### PR DESCRIPTION
Fix a problem discovered by @alexbooth92 and @roland-sipos in the timestamp comparator.
Tested to work both with fake triggers and requests from DS.