### PR TITLE
Candidate changes to the messages associated with a missing raw_recording queue

### DIFF
--- a/include/readout/ReadoutIssues.hpp
+++ b/include/readout/ReadoutIssues.hpp
@@ -89,6 +89,10 @@ ERS_DECLARE_ISSUE_BASE(readout,
                        ((std::string)name),
                        ((std::string)queueType))
 
+ERS_DECLARE_ISSUE(readout, ConfigurationNote, name << ": " << text, ((std::string)name)((std::string)text))
+
+ERS_DECLARE_ISSUE(readout, ConfigurationProblem, name << " configuration problem: " << text, ((std::string)name)((std::string)text))
+
 } // namespace dunedaq
 
 #endif // READOUT_INCLUDE_READOUT_READOUTISSUES_HPP_

--- a/include/readout/models/DefaultRequestHandlerModel.hpp
+++ b/include/readout/models/DefaultRequestHandlerModel.hpp
@@ -15,6 +15,7 @@
 
 #include "readout/datalinkhandler/Structs.hpp"
 
+#include "appfwk/Issues.hpp"
 #include "dataformats/Fragment.hpp"
 #include "dataformats/Types.hpp"
 #include "dfmessages/DataRequest.hpp"
@@ -79,8 +80,26 @@ public:
     try {
       auto queue_index = appfwk::queue_index(args, {"raw_recording"});
       m_snb_sink.reset(new appfwk::DAQSink<ReadoutType>(queue_index["raw_recording"].inst));
+    } catch (const dunedaq::appfwk::InvalidSchema& excpt) {
+      // 28-Jul-2021, KAB: I have split out the handling of the InvalidSchema exception from other exceptions.
+      // At the moment, this 'InvalidSchema' exception seems to be the one that is used to indicate that no
+      // "raw_recording" queue was specified in the system configuration. The absence of this queue is not a
+      // problem, per se, but rather an indication that raw recording is disabled. We've included the reporting
+      // of an Info message in this case in the hope that it might be helpful if/when someone needs to debug why
+      // recording doesn't work later in the life cycle of a particular DAQ instance.
+      // (An aside: I wonder if there might be a better exception to use to indicate the absence of the queue than InvalidSchema.)
+      //
+      // A couple of notes on the particular ERS Issue that I used for the Info message:
+      // * I chose to *not* use a 'severity level' in the name of the message (e.g. I didn't use "Info" in the
+      //   name). This is in keeping with the guidance that we received when ERS Issues were first described, and
+      //   this choice allows the Issue to be reported with whatever severity is appropriate at the time.
+      // * The "module name" that I've specified in this message is not terribly helpful. (There is probably sufficient
+      //   other information in the log that indicates that this message came from the DefaultRequestHandlerModel class.)
+      //   It would be really cool if this class could somehow obtain the name of the DAQModule that it is part of,
+      //   and report the module name.  That might be an enhancement for another time.
+      ers::info(ConfigurationNote(ERS_HERE, "DefaultRequestHandlerModel", "Raw data recording is configured OFF, as indicated by the absence of the raw_recording queue in the initialization of this module."));
     } catch (const ers::Issue& excpt) {
-      ers::warning(ResourceQueueError(ERS_HERE, "DefaultRequestHandlerModel", "raw_recording", excpt));
+      ers::error(ResourceQueueError(ERS_HERE, "DefaultRequestHandlerModel", "raw_recording", excpt));
     }
   }
 
@@ -143,7 +162,14 @@ public:
   void record(const nlohmann::json& args) override
   {
     if (m_snb_sink.get() == nullptr) {
-      TLOG() << "Recording could not be started because output queue is not set up";
+      // 28-Jul-2021, KAB: I've updated the logging of this problem to be an ERS error, since this seems
+      // like a rather severe problem. If someone has tried to send a "record" command to this class and
+      // not provided a suitable queue to send the data on, we definitely should report that problem.
+      //
+      // Another option for the text of this report: "Recording could not be started because the appropriate
+      // output queue (name=\"raw_recording\") was not provided in the initialization of this module."
+      ers::error(ConfigurationProblem(ERS_HERE, "DefaultRequestHandlerModel",
+                                      "Recording could not be started because output queue is not set up."));
       return;
     }
     auto conf = args.get<datalinkhandler::RecordingParams>();

--- a/include/readout/models/DefaultRequestHandlerModel.hpp
+++ b/include/readout/models/DefaultRequestHandlerModel.hpp
@@ -80,14 +80,13 @@ public:
     try {
       auto queue_index = appfwk::queue_index(args, {"raw_recording"});
       m_snb_sink.reset(new appfwk::DAQSink<ReadoutType>(queue_index["raw_recording"].inst));
-    } catch (const dunedaq::appfwk::InvalidSchema& excpt) {
-      // 28-Jul-2021, KAB: I have split out the handling of the InvalidSchema exception from other exceptions.
-      // At the moment, this 'InvalidSchema' exception seems to be the one that is used to indicate that no
+    } catch (const dunedaq::appfwk::QueueNotFound& excpt) {
+      // 28-Jul-2021, KAB: I have split out the handling of the QueueNotFound exception from other exceptions.
+      // This exception seems to be the one that is used to indicate that no
       // "raw_recording" queue was specified in the system configuration. The absence of this queue is not a
       // problem, per se, but rather an indication that raw recording is disabled. We've included the reporting
       // of an Info message in this case in the hope that it might be helpful if/when someone needs to debug why
       // recording doesn't work later in the life cycle of a particular DAQ instance.
-      // (An aside: I wonder if there might be a better exception to use to indicate the absence of the queue than InvalidSchema.)
       //
       // A couple of notes on the particular ERS Issue that I used for the Info message:
       // * I chose to *not* use a 'severity level' in the name of the message (e.g. I didn't use "Info" in the


### PR DESCRIPTION
Hi Florian and Roland,
This PR has the sample code changes that we talked about earlier today.  
Please take a look, when you get a chance, and let me know what you think.
As we discussed earlier, the spirit of my changes was to provide the appropriate severity of messages at the appropriate times.
Hope this is useful,
Kurt