### PR TITLE
Retry counter for requests

### DIFF
--- a/include/readout/models/ReadoutModel.hpp
+++ b/include/readout/models/ReadoutModel.hpp
@@ -44,6 +44,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 using dunedaq::readout::logging::TLVL_QUEUE_POP;
 using dunedaq::readout::logging::TLVL_TAKE_NOTE;

--- a/schema/readout/datalinkhandler.jsonnet
+++ b/schema/readout/datalinkhandler.jsonnet
@@ -50,7 +50,7 @@ local datalinkhandler = {
                 doc="The APA number of this link"),
         s.field("link_number", self.link_number, 0,
                 doc="The link number of this link"),
-        s.field("num_request_handling_threads", self.count, 1,
+        s.field("num_request_handling_threads", self.count, 4,
                 doc="Number of threads to use for data request handling"),
         s.field("postprocess_queue_sizes", self.size, 10000,
                 doc="Size of the queues used for postprocessing"),
@@ -63,7 +63,9 @@ local datalinkhandler = {
         s.field("channel_map_felix", self.file_name, "",
                         doc="Channel map felix file for software TPG. If empty string, look in $READOUT_SHARE"),
         s.field("enable_software_tpg", self.choice, false,
-                doc="Enable software TPG")
+                doc="Enable software TPG"),
+        s.field("retry_count", self.count, 100,
+                doc="Number of times to recheck a request before sending an empty fragment")
     ], doc="Generic readout element configuration"),
 
     recording: s.record("RecordingParams", [

--- a/schema/readout/datalinkhandlerinfo.jsonnet
+++ b/schema/readout/datalinkhandlerinfo.jsonnet
@@ -19,6 +19,7 @@ local info = {
        s.field("request_window_too_old", self.uint8, 0, doc="Request data is already gone"),
        s.field("retry_request", self.uint8, 0, doc="Data is not completely there yet and request can be retried"),
        s.field("uncategorized_request", self.uint8, 0, doc="Request is uncategorized"),
+       s.field("requests_timed_out", self.uint8, 0, doc="Timed out requests"),
        s.field("cleanups", self.uint8, 0, doc="Cleanups issued on the latency buffer"),
        s.field("overwritten_packet_count", self.uint8, 0, doc="Overwritten packets due to the latency buffer being full"),
        s.field("num_waiting_requests", self.uint8, 0, doc="Number of requests that are waiting to be processed"),


### PR DESCRIPTION
Let requests timeout after some time to make sure that a response is always send, even if no new data is coming in