### PR TITLE
Added TLOG messages to DataLinkHandler for do_start and do_stop

### DIFF
--- a/plugins/DataLinkHandler.cpp
+++ b/plugins/DataLinkHandler.cpp
@@ -12,6 +12,7 @@
 
 #include "appfwk/cmd/Nljs.hpp"
 #include "logging/Logging.hpp"
+#include "rcif/cmd/Nljs.hpp"
 
 #include <memory>
 #include <sstream>
@@ -77,6 +78,11 @@ DataLinkHandler::do_start(const data_t& args)
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_start() method";
   m_run_marker.store(true);
   m_readout_impl->start(args);
+
+  rcif::cmd::StartParams start_params = args.get<rcif::cmd::StartParams>();
+  m_run_number = start_params.run;
+  TLOG() << get_name() << " successfully started for run number " << m_run_number;
+
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_start() method";
 }
 
@@ -86,6 +92,7 @@ DataLinkHandler::do_stop(const data_t& args)
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_stop() method";
   m_run_marker.store(false);
   m_readout_impl->stop(args);
+  TLOG() << get_name() << " successfully stopped for run number " << m_run_number;
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_stop() method";
 }
 

--- a/plugins/DataLinkHandler.hpp
+++ b/plugins/DataLinkHandler.hpp
@@ -50,6 +50,7 @@ private:
   // Configuration
   bool m_configured;
   using module_conf_t = datalinkhandler::Conf;
+  dataformats::run_number_t m_run_number;
 
   // Internal
   std::unique_ptr<ReadoutConcept> m_readout_impl;


### PR DESCRIPTION
This is fairly minor, but I often find it helpful to have messages in our daq_application log files that indicate when a given run starts and stops.

This PR adds such messages to the DataLinkHandler plugin.  My assumption is that there will always be at least one DLH in each Readout App, so adding these messages to the DLH code will be sufficient.  I used the same pattern for these messages as what we've done in other places (e.g. dfmodules/plugins/DataWriter.cpp).