### PR TITLE
Fix -Wpessimising-move and -Wredundant-move warnings that occur when

### DIFF
--- a/include/readout/models/DefaultRequestHandlerModel.hpp
+++ b/include/readout/models/DefaultRequestHandlerModel.hpp
@@ -370,7 +370,7 @@ protected:
     fh.sequence_number = dr.sequence_number;
     fh.element_id = { m_geoid.system_type, m_geoid.region_id, m_geoid.element_id };
     fh.fragment_type = static_cast<dataformats::fragment_type_t>(ReadoutType::fragment_type);
-    return std::move(fh);
+    return fh;
   }
 
   std::unique_ptr<dataformats::Fragment> create_empty_fragment(const dfmessages::DataRequest& dr)

--- a/src/CreateReadout.hpp
+++ b/src/CreateReadout.hpp
@@ -61,7 +61,7 @@ createReadout(const nlohmann::json& args, std::atomic<bool>& run_marker)
           FixedRateQueueModel<types::WIB_SUPERCHUNK_STRUCT>,
           WIBFrameProcessor>>(run_marker);
         readout_model->init(args);
-        return std::move(readout_model);
+        return readout_model;
       }
 
       // IF WIB2
@@ -73,7 +73,7 @@ createReadout(const nlohmann::json& args, std::atomic<bool>& run_marker)
           FixedRateQueueModel<types::WIB2_SUPERCHUNK_STRUCT>,
           WIB2FrameProcessor>>(run_marker);
         readout_model->init(args);
-        return std::move(readout_model);
+        return readout_model;
       }
 
       // IF DAPHNE queue
@@ -86,7 +86,7 @@ createReadout(const nlohmann::json& args, std::atomic<bool>& run_marker)
                        BinarySearchQueueModel<types::DAPHNE_SUPERCHUNK_STRUCT>,
                        DAPHNEFrameProcessor>>(run_marker);
         readout_model->init(args);
-        return std::move(readout_model);
+        return readout_model;
       }
 
       // IF PDS skiplist
@@ -97,7 +97,7 @@ createReadout(const nlohmann::json& args, std::atomic<bool>& run_marker)
                                                            SkipListLatencyBufferModel<types::DAPHNE_SUPERCHUNK_STRUCT>,
                                                            DAPHNEFrameProcessor>>(run_marker);
         readout_model->init(args);
-        return std::move(readout_model);
+        return readout_model;
       }
 
       if (inst.find("tp") != std::string::npos) {
@@ -108,7 +108,7 @@ createReadout(const nlohmann::json& args, std::atomic<bool>& run_marker)
           BinarySearchQueueModel<types::TP_READOUT_TYPE>,
           WIBTriggerPrimitiveProcessor>>(run_marker);
         readout_model->init(args);
-        return std::move(readout_model);
+        return readout_model;
       }
 
       // IF ND LAr PACMAN
@@ -119,7 +119,7 @@ createReadout(const nlohmann::json& args, std::atomic<bool>& run_marker)
                                                            SkipListLatencyBufferModel<types::PACMAN_MESSAGE_STRUCT>,
                                                            PACMANFrameProcessor>>(run_marker);
         readout_model->init(args);
-        return std::move(readout_model);
+        return readout_model;
       }
 
       // IF variadic

--- a/src/CreateSourceEmulator.hpp
+++ b/src/CreateSourceEmulator.hpp
@@ -52,7 +52,7 @@ createSourceEmulator(const appfwk::app::QueueInfo qi, std::atomic<bool>& run_mar
 
     auto source_emu_model = std::make_unique<SourceEmulatorModel<types::WIB2_SUPERCHUNK_STRUCT>>(
       qi.name, run_marker, wib2_time_tick_diff, wib2_dropout_rate, wib2_rate_khz);
-    return std::move(source_emu_model);
+    return source_emu_model;
   }
 
   // IF WIB
@@ -60,7 +60,7 @@ createSourceEmulator(const appfwk::app::QueueInfo qi, std::atomic<bool>& run_mar
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake wib link";
     auto source_emu_model = std::make_unique<SourceEmulatorModel<types::WIB_SUPERCHUNK_STRUCT>>(
       qi.name, run_marker, wib_time_tick_diff, wib_dropout_rate, wib_rate_khz);
-    return std::move(source_emu_model);
+    return source_emu_model;
   }
 
   // IF PDS
@@ -68,14 +68,14 @@ createSourceEmulator(const appfwk::app::QueueInfo qi, std::atomic<bool>& run_mar
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake pds link";
     auto source_emu_model = std::make_unique<SourceEmulatorModel<types::DAPHNE_SUPERCHUNK_STRUCT>>(
       qi.name, run_marker, daphne_time_tick_diff, daphne_dropout_rate, daphne_rate_khz);
-    return std::move(source_emu_model);
+    return source_emu_model;
   }
 
   // TP link
   if (inst.find("tp") != std::string::npos) {
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake tp link";
     auto source_emu_model = std::make_unique<TPEmulatorModel>(run_marker, 66.0);
-    return std::move(source_emu_model);
+    return source_emu_model;
   }
 
   return nullptr;


### PR DESCRIPTION
compiling readout with GCC 9.