### PR TITLE
Anders kallesoee/emulator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ daq_add_plugin(DataLinkHandler duneDAQModule LINK_LIBRARIES appfwk::appfwk reado
 daq_add_plugin(DataRecorder duneDAQModule LINK_LIBRARIES appfwk::appfwk readout ${BOOST_LIBS})
 daq_add_plugin(FragmentConsumer duneDAQModule LINK_LIBRARIES appfwk::appfwk readout)
 daq_add_plugin(TimeSyncConsumer duneDAQModule LINK_LIBRARIES appfwk::appfwk readout)
+daq_add_plugin(ErroredFrameConsumer duneDAQModule LINK_LIBRARIES appfwk::appfwk readout)
 
 ##############################################################################
 # Integration tests

--- a/include/readout/ReadoutTypes.hpp
+++ b/include/readout/ReadoutTypes.hpp
@@ -113,6 +113,15 @@ struct WIB_SUPERCHUNK_STRUCT
     }
   }
 
+  void fake_frame_errors(uint16_t* fake_errors) // NOLINT(build/unsigned)
+  {
+    auto wf = reinterpret_cast<dunedaq::dataformats::WIBFrame*>(((uint8_t*)(&data))); // NOLINT
+    for (int i = 0; i < frames_per_element; ++i) {
+      wf->set_wib_errors(fake_errors[i]);
+      wf++;
+    }
+  }
+
   FrameType* begin()
   {
     return reinterpret_cast<FrameType*>(&data[0]); // NOLINT
@@ -176,6 +185,11 @@ struct WIB2_SUPERCHUNK_STRUCT
     }
   }
 
+  void fake_frame_errors(uint16_t* /*fake_errors*/) // NOLINT
+  {
+    // Set error bits in header
+  }
+
   FrameType* begin()
   {
     return reinterpret_cast<FrameType*>(&data[0]); // NOLINT
@@ -236,6 +250,11 @@ struct DAPHNE_SUPERCHUNK_STRUCT
       df->header.timestamp_wf_2 = ts_next >> 32;
       ts_next += offset;
     }
+  }
+
+  void fake_frame_errors(uint16_t* /*fake_errors*/) // NOLINT
+  {
+    // Set frame error bits in header
   }
 
   FrameType* begin()

--- a/include/readout/ReadoutTypes.hpp
+++ b/include/readout/ReadoutTypes.hpp
@@ -107,11 +107,12 @@ struct WIB_SUPERCHUNK_STRUCT
   void fake_timestamp(uint64_t first_timestamp, uint64_t offset = 25) // NOLINT(build/unsigned)
   {
     uint64_t ts_next = first_timestamp; // NOLINT(build/unsigned)
+    auto wf = reinterpret_cast<dunedaq::dataformats::WIBFrame*>(((uint8_t*)(&data))); // NOLINT
     for (unsigned int i = 0; i < 12; ++i) {
-      auto wf = reinterpret_cast<dunedaq::dataformats::WIBFrame*>(((uint8_t*)(&data)) + i * 464); // NOLINT
       auto wfh = const_cast<dunedaq::dataformats::WIBHeader*>(wf->get_wib_header());
       wfh->set_timestamp(ts_next);
       ts_next += offset;
+      wf++;
     }
   }
 

--- a/include/readout/ReadoutTypes.hpp
+++ b/include/readout/ReadoutTypes.hpp
@@ -22,6 +22,7 @@
 
 #include <cstdint> // uint_t types
 #include <memory>  // unique_ptr
+#include <vector>
 
 namespace dunedaq {
 namespace readout {
@@ -97,6 +98,7 @@ struct WIB_SUPERCHUNK_STRUCT
     return reinterpret_cast<const dunedaq::dataformats::WIBFrame*>(&data)->get_wib_header()->get_timestamp(); // NOLINT
   }
 
+  // RS -> WHY????
   void set_timestamp(uint64_t ts) // NOLINT(build/unsigned)
   {
     reinterpret_cast<dunedaq::dataformats::WIBFrame*>(&data)->get_wib_header()->set_timestamp(ts); // NOLINT
@@ -113,11 +115,11 @@ struct WIB_SUPERCHUNK_STRUCT
     }
   }
 
-  void fake_frame_errors(uint16_t* fake_errors) // NOLINT(build/unsigned)
+  void fake_frame_errors(std::vector<uint16_t>* fake_errors) // NOLINT(build/unsigned)
   {
     auto wf = reinterpret_cast<dunedaq::dataformats::WIBFrame*>(((uint8_t*)(&data))); // NOLINT
     for (int i = 0; i < frames_per_element; ++i) {
-      wf->set_wib_errors(fake_errors[i]);
+      wf->set_wib_errors((*fake_errors)[i]);
       wf++;
     }
   }
@@ -185,7 +187,7 @@ struct WIB2_SUPERCHUNK_STRUCT
     }
   }
 
-  void fake_frame_errors(uint16_t* /*fake_errors*/) // NOLINT
+  void fake_frame_errors(std::vector<uint16_t>* /*fake_errors*/) // NOLINT
   {
     // Set error bits in header
   }
@@ -252,7 +254,7 @@ struct DAPHNE_SUPERCHUNK_STRUCT
     }
   }
 
-  void fake_frame_errors(uint16_t* /*fake_errors*/) // NOLINT
+  void fake_frame_errors(std::vector<uint16_t>* /*fake_errors*/) // NOLINT
   {
     // Set frame error bits in header
   }

--- a/include/readout/models/SourceEmulatorModel.hpp
+++ b/include/readout/models/SourceEmulatorModel.hpp
@@ -198,14 +198,8 @@ protected:
         std::vector<uint16_t> frame_errs;  // NOLINT(build/unsigned)
         for (int i = 0; i < rptr->frames_per_element; ++i){
           frame_errs.push_back(m_error_bit_generator.next());
-//          if (f_count % 100 == 0){
-//            frame_errs.push_back(1);
-//          } else {
-//            frame_errs.push_back(0);
-//          }
-//          f_count++;
         }
-//        payload.fake_frame_errors(&frame_errs);
+        payload.fake_frame_errors(&frame_errs);
 
         // queue in to actual DAQSink
         try {
@@ -229,7 +223,6 @@ protected:
   }
 
 private:
-  int f_count = 0;
   // Constuctor params
   std::atomic<bool>& m_run_marker;
 

--- a/include/readout/models/SourceEmulatorModel.hpp
+++ b/include/readout/models/SourceEmulatorModel.hpp
@@ -33,6 +33,9 @@
 #include <utility>
 #include <vector>
 
+#include <chrono>
+#include "unistd.h"
+
 using dunedaq::readout::logging::TLVL_TAKE_NOTE;
 using dunedaq::readout::logging::TLVL_WORK_STEPS;
 
@@ -192,17 +195,17 @@ protected:
         payload.fake_timestamp(timestamp, m_time_tick_diff);
 
         // Introducing frame errors
-        uint16_t frame_errs[rptr->frames_per_element];  // NOLINT(build/unsigned)
-        for (int i = 0; i < rptr->frames_per_element; ++i) {
-//          frame_errs[i] = m_error_bit_generator.next();
-          if (f_count % 99 == 0){
-            frame_errs[i] = 1;
-          } else {
-            frame_errs[i] = 0;
-          }
-          f_count++;
+        std::vector<uint16_t> frame_errs;  // NOLINT(build/unsigned)
+        for (int i = 0; i < rptr->frames_per_element; ++i){
+          frame_errs.push_back(m_error_bit_generator.next());
+//          if (f_count % 100 == 0){
+//            frame_errs.push_back(1);
+//          } else {
+//            frame_errs.push_back(0);
+//          }
+//          f_count++;
         }
-        payload.fake_frame_errors(frame_errs);
+//        payload.fake_frame_errors(&frame_errs);
 
         // queue in to actual DAQSink
         try {

--- a/include/readout/models/TaskRawDataProcessorModel.hpp
+++ b/include/readout/models/TaskRawDataProcessorModel.hpp
@@ -118,20 +118,10 @@ public:
     m_post_process_functions.push_back(std::forward<Task>(task));
   }
 
-  int t_count = 0;
   void invoke_all_preprocess_functions(ReadoutType* item)
   {
     for (auto&& task : m_preprocess_functions) {
-      if (t_count < 100){
-        auto t1 = std::chrono::high_resolution_clock::now();
-        task(item);
-        auto t2 = std::chrono::high_resolution_clock::now();
-        auto dur = std::chrono::duration_cast<std::chrono::microseconds>(t2-t1);
-        TLOG() << "preprocessing task execution time: " << dur.count();
-      } else {
-        task(item);
-      }
-      t_count++;
+      task(item);
     }
   }
 

--- a/include/readout/models/TaskRawDataProcessorModel.hpp
+++ b/include/readout/models/TaskRawDataProcessorModel.hpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <chrono>
 
 using dunedaq::readout::logging::TLVL_WORK_STEPS;
 
@@ -117,10 +118,20 @@ public:
     m_post_process_functions.push_back(std::forward<Task>(task));
   }
 
+  int t_count = 0;
   void invoke_all_preprocess_functions(ReadoutType* item)
   {
     for (auto&& task : m_preprocess_functions) {
-      task(item);
+      if (t_count < 100){
+        auto t1 = std::chrono::high_resolution_clock::now();
+        task(item);
+        auto t2 = std::chrono::high_resolution_clock::now();
+        auto dur = std::chrono::duration_cast<std::chrono::microseconds>(t2-t1);
+        TLOG() << "preprocessing task execution time: " << dur.count();
+      } else {
+        task(item);
+      }
+      t_count++;
     }
   }
 

--- a/include/readout/utils/ErrorBitGenerator.hpp
+++ b/include/readout/utils/ErrorBitGenerator.hpp
@@ -1,0 +1,92 @@
+/**
+ * @file ErrorBitGenerator.hpp Utility to deliver error bits as integers to the source emulator
+ * This is part of the DUNE DAQ , copyright 2021.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef READOUT_INCLUDE_READOUT_UTILS_ERRORBITGENERATOR_HPP_
+#define READOUT_INCLUDE_READOUT_UTILS_ERRORBITGENERATOR_HPP_
+
+#include <random>
+#include <unistd.h>
+
+namespace dunedaq {
+namespace readout {
+
+/** ErrorBitGenerator usage:
+ *
+ * auto ebg = ErrorBitGenerator(1.0)
+ * ebg.generate();
+ * uint16_t errs = ebg.next();
+ *
+ */
+
+class ErrorBitGenerator
+{
+public:
+  explicit ErrorBitGenerator(double rate = 0)
+    : m_error_rate(rate)
+    , m_error_bits_index(0)
+    , m_error_occurrences_index(0)
+    , m_no_error_occurrences_index(0)
+    , m_current_occurrence(0)
+    , m_occurrence_count(0)
+    , m_set_error_bits(true)
+  {}
+  uint16_t next() // NOLINT(build/unsigned)
+  {
+    if (m_occurrence_count >= m_current_occurrence) {
+      if (m_set_error_bits) {
+        m_error_bits_index = (m_error_bits_index + 1) % 1000;
+        m_error_occurrences_index = (m_error_occurrences_index + 1) % 1000;
+        m_set_error_bits = false;
+        m_current_occurrence = m_no_error_occurrences[m_no_error_occurrences_index];
+        m_occurrence_count = 0;
+      } else {
+        m_no_error_occurrences_index = (m_no_error_occurrences_index + 1) % 1000;
+        m_set_error_bits = true;
+        m_current_occurrence = m_error_occurrences[m_error_occurrences_index];
+        m_occurrence_count = 0;
+      }
+    }
+    m_occurrence_count++;
+    return m_set_error_bits ? m_error_bits[m_error_bits_index] : 0;
+  }
+
+  void generate()
+  {
+//    TLOG() << "M_ERROR_RATE: " << m_error_rate;
+    std::random_device rd;
+    std::mt19937 mt(rd());
+    std::uniform_int_distribution<uint16_t> err_bit_dis(0, 65535);  // NOLINT(build/unsigned)
+    std::uniform_int_distribution<int> duration_dis(1, 1000000);
+
+    for (int i = 0; i < 1000; ++i) {
+      m_error_bits[i] = err_bit_dis(mt);
+    }
+    for (int i = 0; i < 1000; ++i) {
+      m_error_occurrences[i] = duration_dis(mt) * m_error_rate;
+//      TLOG() << "M_ERROR_OCCURRENCES_" << i << ": " << m_error_occurrences[i];
+      m_no_error_occurrences[i] = duration_dis(mt) * (1 - m_error_rate);
+//      TLOG() << "M_NO_ERROR_OCCURRENCES_" << i << ": " << m_no_error_occurrences;
+    }
+  }
+
+private:
+  double m_error_rate;
+  uint16_t m_error_bits[1000]; // NOLINT(build/unsigned)
+  int m_error_bits_index;
+  int m_error_occurrences[1000];
+  int m_error_occurrences_index;
+  int m_no_error_occurrences[1000];
+  int m_no_error_occurrences_index;
+  int m_current_occurrence;
+  int m_occurrence_count;
+  bool m_set_error_bits;
+};
+
+} // namespace readout
+} // namespace dunedaq
+
+#endif // READOUT_INCLUDE_READOUT_UTILS_ERRORBITGENERATOR_HPP_

--- a/include/readout/utils/ErrorBitGenerator.hpp
+++ b/include/readout/utils/ErrorBitGenerator.hpp
@@ -38,42 +38,40 @@ public:
   {
     if (m_occurrence_count >= m_current_occurrence) {
       if (m_set_error_bits) {
-        m_error_bits_index = (m_error_bits_index + 1) % 1000;
-        m_error_occurrences_index = (m_error_occurrences_index + 1) % 1000;
+        m_error_bits_index = (m_error_bits_index + 1) % m_size;
+        m_error_occurrences_index = (m_error_occurrences_index + 1) % m_size;
         m_set_error_bits = false;
         m_current_occurrence = m_no_error_occurrences[m_no_error_occurrences_index];
         m_occurrence_count = 0;
       } else {
-        m_no_error_occurrences_index = (m_no_error_occurrences_index + 1) % 1000;
+        m_no_error_occurrences_index = (m_no_error_occurrences_index + 1) % m_size;
         m_set_error_bits = true;
         m_current_occurrence = m_error_occurrences[m_error_occurrences_index];
         m_occurrence_count = 0;
       }
     }
     m_occurrence_count++;
-    return m_set_error_bits ? m_error_bits[m_error_bits_index] : 0;
+    return (m_set_error_bits && m_current_occurrence) ? m_error_bits[m_error_bits_index] : 0;
   }
 
   void generate()
   {
-//    TLOG() << "M_ERROR_RATE: " << m_error_rate;
     std::random_device rd;
     std::mt19937 mt(rd());
     std::uniform_int_distribution<uint16_t> err_bit_dis(0, 65535);  // NOLINT(build/unsigned)
-    std::uniform_int_distribution<int> duration_dis(1, 1000000);
+    std::uniform_int_distribution<int> duration_dis(1, 100000);
 
-    for (int i = 0; i < 1000; ++i) {
+    for (int i = 0; i < m_size; ++i) {
       m_error_bits[i] = err_bit_dis(mt);
     }
-    for (int i = 0; i < 1000; ++i) {
+    for (int i = 0; i < m_size; ++i) {
       m_error_occurrences[i] = duration_dis(mt) * m_error_rate;
-//      TLOG() << "M_ERROR_OCCURRENCES_" << i << ": " << m_error_occurrences[i];
       m_no_error_occurrences[i] = duration_dis(mt) * (1 - m_error_rate);
-//      TLOG() << "M_NO_ERROR_OCCURRENCES_" << i << ": " << m_no_error_occurrences;
     }
   }
 
 private:
+  int m_size = 1000;
   double m_error_rate;
   uint16_t m_error_bits[1000]; // NOLINT(build/unsigned)
   int m_error_bits_index;

--- a/plugins/ErroredFrameConsumer.cpp
+++ b/plugins/ErroredFrameConsumer.cpp
@@ -34,8 +34,8 @@ public:
   {
     if (packet.get_wib_header()->wib_errors){
       m_error_count += std::bitset<16>(packet.get_wib_header()->wib_errors).count();
-      TLOG() << "ErrorFrameConsumer recieved errors: " << std::bitset<16>(packet.get_wib_header()->wib_errors)
-          << " Total number of errors are: " << m_error_count;
+//      TLOG() << "bitset: " << std::bitset<16>(packet.get_wib_header()->wib_errors)
+//          << " error count: " << m_error_count;
     }
   }
 private:

--- a/plugins/ErroredFrameConsumer.cpp
+++ b/plugins/ErroredFrameConsumer.cpp
@@ -1,0 +1,49 @@
+/**
+ * @file ErroredFrameConsumer.cpp Module that consumes frames with errors from a queue
+ *
+ * This is part of the DUNE DAQ , copyright 2020.
+ * Licencing/copyright details are in the COPYING file that you should have
+ * recieved with this code.
+ * */
+
+#ifndef READOUT_PLUGINS_ERROREDFRAMECONSUMER_HPP_
+#define READOUT_PLUGINS_ERROREDFRAMECONSUMER_HPP_
+
+#include "readout/ReadoutLogging.hpp"
+#include "DummyConsumer.cpp"
+#include "DummyConsumer.hpp"
+#include "logging/Logging.hpp"
+#include "dataformats/wib/WIBFrame.hpp"
+
+#include <bitset>
+
+#include <memory>
+#include <string>
+
+namespace dunedaq {
+namespace readout {
+
+class ErroredFrameConsumer : public DummyConsumer<dataformats::WIBFrame>
+{
+public:
+  explicit ErroredFrameConsumer(const std::string name)
+  : DummyConsumer<dataformats::WIBFrame>(name)
+  {}
+
+  void packet_callback(dataformats::WIBFrame& packet) override
+  {
+    if (packet.get_wib_header()->wib_errors){
+      m_error_count += std::bitset<16>(packet.get_wib_header()->wib_errors).count();
+      TLOG() << "ErrorFrameConsumer recieved errors: " << std::bitset<16>(packet.get_wib_header()->wib_errors)
+          << " Total number of errors are: " << m_error_count;
+    }
+  }
+private:
+  int m_error_count;
+};
+} // namespace readout
+} // namespace dunedaq
+
+DEFINE_DUNE_DAQ_MODULE(dunedaq::readout::ErroredFrameConsumer)
+
+#endif // READOUT_PLUGINS_ERROREDFRAMECONSUMER_HPP_

--- a/python/readout/app_confgen.py
+++ b/python/readout/app_confgen.py
@@ -173,7 +173,6 @@ def generate(
                             element_id = idx,
                             enable_software_tpg = ENABLE_SOFTWARE_TPG,
                             max_queued_errored_frames = 100,
-                            num_error_reset = 100,
                         ),
                         requesthandlerconf= rconf.RequestHandlerConf(
                             latency_buffer_size = 3*CLOCK_SPEED_HZ/(25*12*DATA_RATE_SLOWDOWN_FACTOR),

--- a/schema/readout/readoutconfig.jsonnet
+++ b/schema/readout/readoutconfig.jsonnet
@@ -75,9 +75,7 @@ local readoutconfig = {
             s.field("element_id", self.element_id, 0,
                             doc="The element id of this link"),
             s.field("max_queued_errored_frames", self.size, 100,
-                            doc="Maximum number of frames queued per error type"),
-            s.field("num_error_reset", self.size, 100,
-                            doc="Number of error free frames required to reset buffering of errored frames")],
+                            doc="Maximum number of frames queued per error type")],
             doc="RawDataProcessor Config"),
 
     requesthandlerconf : s.record("RequestHandlerConf", [

--- a/schema/readout/readoutconfig.jsonnet
+++ b/schema/readout/readoutconfig.jsonnet
@@ -73,7 +73,11 @@ local readoutconfig = {
             s.field("region_id", self.region_id, 0,
                             doc="The region id of this link"),
             s.field("element_id", self.element_id, 0,
-                            doc="The element id of this link")],
+                            doc="The element id of this link"),
+            s.field("max_queued_errored_frames", self.size, 100,
+                            doc="Maximum number of frames queued per error type"),
+            s.field("num_error_reset", self.size, 100,
+                            doc="Number of error free frames required to reset buffering of errored frames")],
             doc="RawDataProcessor Config"),
 
     requesthandlerconf : s.record("RequestHandlerConf", [

--- a/schema/readout/readoutinfo.jsonnet
+++ b/schema/readout/readoutinfo.jsonnet
@@ -22,7 +22,8 @@ local info = {
         s.field("num_tps_sent",                  self.uint8,     0, doc="Number of sent TPs"),
         s.field("num_tpsets_sent",               self.uint8,     0, doc="Number of sent TPSets"),
         s.field("num_tps_dropped",               self.uint8,     0, doc="Number of dropped TPs (because they were too old)"),
-        s.field("rate_tp_hits",                  self.float8,    0, doc="TP hit rate in kHz")
+        s.field("rate_tp_hits",                  self.float8,    0, doc="TP hit rate in kHz"),
+        s.field("num_frame_errors",              self.uint8,     0, doc="Total number of frame errors")
    ], doc="Latency buffer information"),
 
    requesthandlerinfo: s.record("RequestHandlerInfo", [

--- a/schema/readout/sourceemulatorconfig.jsonnet
+++ b/schema/readout/sourceemulatorconfig.jsonnet
@@ -22,6 +22,9 @@ local sourceemulatorconfig = {
     khz  : s.number("khz", "f8",
                      doc="A frequency in kHz"),
 
+    double8 : s.number("double8", "f8",
+                     doc="floating point of 8 bytes"),
+
     slowdown_t : s.number("slowdown_t", "f8",
                      doc="Slowdown factor"),
   
@@ -55,7 +58,9 @@ local sourceemulatorconfig = {
         s.field("queue_name", self.string,
             doc="Name of the output queue"),
         s.field("random_population_size", self.uint4, 10000,
-            doc="Size of the random population")
+            doc="Size of the random population"),
+        s.field("emu_frame_error_rate", self.double8, 0.0,
+            doc="Rate of faked errors in frame header"),
         ], doc="Configuration for one link"),
 
     link_conf_list : s.sequence("link_conf_list", self.link_conf, doc="Link configuration list"),

--- a/src/CreateReadout.hpp
+++ b/src/CreateReadout.hpp
@@ -101,7 +101,7 @@ createReadout(const nlohmann::json& args, std::atomic<bool>& run_marker)
       }
 
       if (inst.find("tp") != std::string::npos) {
-        TLOG(TLVL_WORK_STEPS) << "Creating readout for tp";
+        TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating readout for tp";
         auto readout_model = std::make_unique<ReadoutModel<
           types::TP_READOUT_TYPE,
           EmptyFragmentRequestHandlerModel<types::TP_READOUT_TYPE, BinarySearchQueueModel<types::TP_READOUT_TYPE>>,

--- a/src/CreateSourceEmulator.hpp
+++ b/src/CreateSourceEmulator.hpp
@@ -44,6 +44,8 @@ createSourceEmulator(const appfwk::app::QueueInfo qi, std::atomic<bool>& run_mar
   static constexpr double wib2_dropout_rate = 0.0;
   static constexpr double wib2_rate_khz = 166.0;
 
+  static constexpr double emu_frame_error_rate = 0.0;
+
   auto& inst = qi.inst;
 
   // IF WIB2
@@ -51,7 +53,7 @@ createSourceEmulator(const appfwk::app::QueueInfo qi, std::atomic<bool>& run_mar
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake wib2 link";
 
     auto source_emu_model = std::make_unique<SourceEmulatorModel<types::WIB2_SUPERCHUNK_STRUCT>>(
-      qi.name, run_marker, wib2_time_tick_diff, wib2_dropout_rate, wib2_rate_khz);
+      qi.name, run_marker, wib2_time_tick_diff, wib2_dropout_rate, emu_frame_error_rate, wib2_rate_khz);
     return std::move(source_emu_model);
   }
 
@@ -59,7 +61,7 @@ createSourceEmulator(const appfwk::app::QueueInfo qi, std::atomic<bool>& run_mar
   if (inst.find("wib") != std::string::npos) {
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake wib link";
     auto source_emu_model = std::make_unique<SourceEmulatorModel<types::WIB_SUPERCHUNK_STRUCT>>(
-      qi.name, run_marker, wib_time_tick_diff, wib_dropout_rate, wib_rate_khz);
+      qi.name, run_marker, wib_time_tick_diff, wib_dropout_rate, emu_frame_error_rate, wib_rate_khz);
     return std::move(source_emu_model);
   }
 
@@ -67,7 +69,7 @@ createSourceEmulator(const appfwk::app::QueueInfo qi, std::atomic<bool>& run_mar
   if (inst.find("pds") != std::string::npos) {
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake pds link";
     auto source_emu_model = std::make_unique<SourceEmulatorModel<types::DAPHNE_SUPERCHUNK_STRUCT>>(
-      qi.name, run_marker, daphne_time_tick_diff, daphne_dropout_rate, daphne_rate_khz);
+      qi.name, run_marker, daphne_time_tick_diff, daphne_dropout_rate, emu_frame_error_rate, daphne_rate_khz);
     return std::move(source_emu_model);
   }
 


### PR DESCRIPTION
I removed the buffering of the frames and the async calls. Now a configurable number of frames (m_max_queued_errored_frames) will be pushed to the queue, after that every 10000th frame with the same error will be pushed. This is much simpler than the previous design and it seems to run with no issues even with errors in every frame. 